### PR TITLE
Fix possible buffer overrun

### DIFF
--- a/Source/PacketizedTCP.cpp
+++ b/Source/PacketizedTCP.cpp
@@ -87,8 +87,8 @@ bool PacketizedTCP::SendList( const char **data, const unsigned int *lengths, co
 #endif
 	
 
-	unsigned int lengthsArray[512];
-	const char *dataArray[512];
+	unsigned int lengthsArray[513];
+	const char *dataArray[513];
 	dataArray[0]=(char*) &dataLength;
 	lengthsArray[0]=sizeof(dataLength);
 	for (int i=0; i < 512 && i < numParameters; i++)

--- a/Source/RakNetSocket2_Berkley_NativeClient.cpp
+++ b/Source/RakNetSocket2_Berkley_NativeClient.cpp
@@ -33,7 +33,7 @@ void DomainNameToIP_Berkley_IPV4And6( const char *domainName, char ip[65] )
 	hints.ai_socktype = SOCK_DGRAM;
 
 	if ((status = getaddrinfo(domainName, NULL, &hints, &res)) != 0) {
-		memset(ip, 0, sizeof(ip));
+		memset(ip, 0, 65); // sizeof(ip) returns pointer size, not array size
 		return;
 	}
 


### PR DESCRIPTION
these arrays may be accessed at (1..512) below

```
for (int i=0; i < 512 && i < numParameters; i++)
{
    dataArray[i+1]=data[i];
    lengthsArray[i+1]=lengths[i];
}   
```
