### PR TITLE
Fix mismatching allocation/deallocation in AutoPatcher/CreatePatch.cpp

### DIFF
--- a/DependentExtensions/Autopatcher/CreatePatch.cpp
+++ b/DependentExtensions/Autopatcher/CreatePatch.cpp
@@ -576,7 +576,7 @@ int TestDiffInMemory(int argc,char *argv[])
 	fwrite(out,outSize,1,pf);
 	fclose(pf);
 
-	free(out);
+	delete[] out;
 	return res;
 }
 


### PR DESCRIPTION
This PR fixes a mismatching allocation/deallocation of a char array in
the AutoPatcher code:

CreatePatch.cpp:529: _out = new char[_outSize];
CreatePatch.cpp:579: free(out);

Mixing up new/delete and malloc/free is undefined behaviour and should be
avoided.
