### PR TITLE
Fix Issue #13 - It is possible !outputQueue.Empty() should be used instead of outputQueue.size()

### DIFF
--- a/Source/DS_WeightedGraph.h
+++ b/Source/DS_WeightedGraph.h
@@ -280,7 +280,7 @@ namespace DataStructures
 				if (row==0)
 				{
 					path.Insert(startNode, _FILE_AND_LINE_);
-					for (col=0; col<outputQueue.Size(); col++)
+					for (col=0; outputQueue.Size(); col++)
 						path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 					return true;
 				}
@@ -296,7 +296,7 @@ namespace DataStructures
 		}
 
 		path.Insert(startNode, _FILE_AND_LINE_);
-		for (col=0; col<outputQueue.Size(); col++)
+		for (col=0; outputQueue.Size(); col++)
 			path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 		return true;
 	}

--- a/Source/DS_WeightedGraph.h
+++ b/Source/DS_WeightedGraph.h
@@ -280,7 +280,7 @@ namespace DataStructures
 				if (row==0)
 				{
 					path.Insert(startNode, _FILE_AND_LINE_);
-					for (col=0; !outputQueue.Empty(); col++)
+					while (!outputQueue.Empty())
 						path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 					return true;
 				}
@@ -296,7 +296,7 @@ namespace DataStructures
 		}
 
 		path.Insert(startNode, _FILE_AND_LINE_);
-		for (col=0; !outputQueue.Empty(); col++)
+		while (!outputQueue.Empty())
 			path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 		return true;
 	}

--- a/Source/DS_WeightedGraph.h
+++ b/Source/DS_WeightedGraph.h
@@ -280,7 +280,7 @@ namespace DataStructures
 				if (row==0)
 				{
 					path.Insert(startNode, _FILE_AND_LINE_);
-					for (col=0; outputQueue.Size(); col++)
+					for (col=0; !outputQueue.Empty(); col++)
 						path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 					return true;
 				}
@@ -296,7 +296,7 @@ namespace DataStructures
 		}
 
 		path.Insert(startNode, _FILE_AND_LINE_);
-		for (col=0; outputQueue.Size(); col++)
+		for (col=0; !outputQueue.Empty(); col++)
 			path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 		return true;
 	}

--- a/Source/DS_WeightedGraph.h
+++ b/Source/DS_WeightedGraph.h
@@ -280,7 +280,7 @@ namespace DataStructures
 				if (row==0)
 				{
 					path.Insert(startNode, _FILE_AND_LINE_);
-					for (col=0; outputQueue.Size(); col++)
+					for (col=0; col<outputQueue.Size(); col++)
 						path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 					return true;
 				}
@@ -296,7 +296,7 @@ namespace DataStructures
 		}
 
 		path.Insert(startNode, _FILE_AND_LINE_);
-		for (col=0; outputQueue.Size(); col++)
+		for (col=0; col<outputQueue.Size(); col++)
 			path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
 		return true;
 	}


### PR DESCRIPTION
Following further discussion on this Issue the desired fix is to refactor to the equivalent, slightly more elegant form

```
for (col=0; !outputQueue.Empty(); col++)
    path.Insert(outputQueue.Pop(), _FILE_AND_LINE_);
```

.. given for()'s second argument is expecting an expression which is contextually convertible to bool and that using .Size() there is an implicit conversion between size_t and bool (0 = false, 1+ = true)
