### PR TITLE
Removed the unsetting of ${libPortAudioCpp}

### DIFF
--- a/CmakeIncludes/FindPortAudio.cmake
+++ b/CmakeIncludes/FindPortAudio.cmake
@@ -15,15 +15,13 @@ find_path(PORTAUDIO_INCLUDE_DIR portaudio.h
 )
 
 
-
-# finally the library itself
+# Finally the library itself.
 find_library(libPortAudio NAMES portaudio)
 find_library(libPortAudioCpp NAMES portaudiocpp)
-set(libPortAudioCpp "")
 set(PORTAUDIO_LIBRARIES ${libPortAudio} ${libPortAudioCpp})
 
-# handle the QUIETLY and REQUIRED arguments and set PORTAUDIO_FOUND to TRUE if
-# all listed variables are TRUE
+# Handle the QUIETLY and REQUIRED arguments and set PORTAUDIO_FOUND to TRUE if
+# all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PortAudio DEFAULT_MSG PORTAUDIO_LIBRARIES PORTAUDIO_INCLUDE_DIR)
 


### PR DESCRIPTION
I was trying to use your cmake-file for one of my projects, though it didn't find the cpp-library correctly. Took a quick peek in the file and found that the variable was unset quickly after it was set and just before it was used. This pull request corrects this.