### PR TITLE
Fixed an 'comparison between pointer and integer' error on clang std=c++...

### DIFF
--- a/Source/ReplicaManager3.cpp
+++ b/Source/ReplicaManager3.cpp
@@ -138,7 +138,7 @@ void ReplicaManager3::AutoCreateConnectionList(
 {
 	for (unsigned int index=0; index < participantListIn.Size(); index++)
 	{
-		if (GetConnectionByGUID(participantListIn[index], worldId)==false)
+		if (GetConnectionByGUID(participantListIn[index], worldId)==NULL)
 		{
 			Connection_RM3 *connection = AllocConnection(rakPeerInterface->GetSystemAddressFromGuid(participantListIn[index]), participantListIn[index]);
 			if (connection)


### PR DESCRIPTION
Heya,

On Clang 3.4, with C++11 mode, there's a build error stemming from the comparison of integer and pointer. I don't think this should be an error according to the standard, but I figure that 'NULL' and 'false' are fully interchangeable in this context, so I changed the pointer comparison to be against 'NULL'.

Thanks,
tz
