### PR TITLE
Fix: RakString::Assign error when the _vsnprintf() length is larger than 512 in Linux.

### DIFF
--- a/Source/RakString.cpp
+++ b/Source/RakString.cpp
@@ -1377,7 +1377,7 @@ void RakString::Assign(const char *str, va_list ap)
 	if (_vsnprintf(stackBuff, 512, str, ap)!=-1
 #ifndef _WIN32
 		// Here Windows will return -1 if the string is too long; Linux just truncates the string.
-		&& strlen(str) <511
+		&& strlen(stackBuff) <511
 #endif
 		)
 	{


### PR DESCRIPTION
Just a typo error, i think.
