### PR TITLE
Add missing read alignment in ReplicaManager3::OnConstruction

### DIFF
--- a/Source/ReplicaManager3.cpp
+++ b/Source/ReplicaManager3.cpp
@@ -1185,6 +1185,7 @@ PluginReceiveResult ReplicaManager3::OnConstruction(Packet *packet, unsigned cha
 			}
 		}
 	}
+	bsIn.AlignReadToByteBoundary();
 
 	for (index=0; index < constructionObjectListSize; index++)
 	{


### PR DESCRIPTION
When writing the Construction/Destruction packet an alignment is added regardless of if PostSerializeConstruction data is written. This can be found at ReplicaManager3.cpp:2288. 

The alignment is missing in the corresponding read logic, and causes missing Replica destructions on clients when a packet includes both creations and deletions.
