### PR TITLE
UDP co-ordinator fix

### DIFF
--- a/Source/UDPProxyCoordinator.cpp
+++ b/Source/UDPProxyCoordinator.cpp
@@ -44,7 +44,7 @@ int UDPProxyCoordinator::ForwardingRequestComp( const SenderAndTargetAddress &ke
 	if (key.senderClientAddress < data->sata.senderClientAddress )
 		return -1;
 	if (key.senderClientAddress > data->sata.senderClientAddress )
-		return -1;
+		return 1;
 	if (key.targetClientAddress < data->sata.targetClientAddress )
 		return -1;
 	if (key.targetClientAddress > data->sata.targetClientAddress )


### PR DESCRIPTION
The compare function used for ordering forwardingRequestList was wrong, which meant sometimes after the UDP co-ordinator inserted a forwarding request, if it tried to find it again with GetIndexFromKey, it would sometimes fail.

This meant that when it heard back from the proxy about a successful forwarding, it would sometimes not be able to find the original request, thus ignoring the response.

This resulted in clients which needed forwarding successfully getting it set up, but not hearing back about it.
