### PR TITLE
Fix memory leak in TCPInterface (CVSS score: 4.8)

### DIFF
--- a/Source/TCPInterface.cpp
+++ b/Source/TCPInterface.cpp
@@ -306,6 +306,11 @@ void TCPInterface::Stop(void)
 	RakNet::OP_DELETE_ARRAY(remoteClients,_FILE_AND_LINE_);
 	remoteClients=0;
 
+	Packet* packet = incomingMessages.Pop();
+	while (packet != nullptr) {
+		DeallocatePacket(packet);
+		packet = incomingMessages.Pop();
+	}
 	incomingMessages.Clear(_FILE_AND_LINE_);
 	newIncomingConnections.Clear(_FILE_AND_LINE_);
 	newRemoteClients.Clear(_FILE_AND_LINE_);


### PR DESCRIPTION
This is a backport of a security relevant fix for RakNet which was brought to our attention by a user. The issue has already been fixed in SLikeNet 0.1.1 (see https://www.slikenet.com/).
We provide this backport for people who prefer to stick with the RakNet project and also in order to easier share this fix with other RakNet forks.

CVSS Base score: 5.3
CVSS Temporal score: 4.8
CVSS Overall score: 4.8
CVSS v3 Vector: AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C

The security implications of the issue are medium to low in our opinion. Ultimately, the vulnerability can be utilized to run a DoS attack on a susceptible server. A successful attack will result in the server running out of memory and will eventually cause the server application to crash.
An application is however only susceptive, if it utilizes TCP connections. Furthermore, the attack is dependent on conditions which are usually outside the realm of the attacker (i.e. depends on when the server closes a TCP connection and whether internal data was already processed).

For further details, please refer to the original issue report: https://github.com/SLikeSoft/SLikeNet/issues/18
