### PR TITLE
Fix endless loop upon large NAK ranges (CVSS score: 7.2)

### DIFF
--- a/Source/ReliabilityLayer.cpp
+++ b/Source/ReliabilityLayer.cpp
@@ -817,12 +817,12 @@ bool ReliabilityLayer::HandleSocketReceiveFromConnectedPlayer(
 		}
 		for (i=0; i<incomingNAKs.ranges.Size();i++)
 		{
-			if (incomingNAKs.ranges[i].minIndex>incomingNAKs.ranges[i].maxIndex)
+			if (incomingNAKs.ranges[i].minIndex > incomingNAKs.ranges[i].maxIndex || (incomingNAKs.ranges[i].maxIndex == (uint24_t)(0xFFFFFFFF)))
 			{
 				RakAssert(incomingNAKs.ranges[i].minIndex<=incomingNAKs.ranges[i].maxIndex);
 
 				for (unsigned int messageHandlerIndex=0; messageHandlerIndex < messageHandlerList.Size(); messageHandlerIndex++)
-					messageHandlerList[messageHandlerIndex]->OnReliabilityLayerNotification("incomingNAKs minIndex>maxIndex", BYTES_TO_BITS(length), systemAddress, true);			
+					messageHandlerList[messageHandlerIndex]->OnReliabilityLayerNotification("incomingNAKs minIndex > maxIndex or maxIndex is max value", BYTES_TO_BITS(length), systemAddress, true);
 
 				return false;
 			}


### PR DESCRIPTION
This is a backport of a security relevant fix for RakNet (fixes part of issue #102) which was brought to our attention by a user -  see https://github.com/SLikeSoft/SLikeNet/issues/32 for details. The issue has already been fixed in SLikeNet 0.1.2 (see https://www.slikenet.com/).
We provide this backport for people who prefer to stick with the RakNet project and also in order to easier share this fix with other RakNet forks.

CVSS Base score: 7.5
CVSS Temporal score: 7.2
CVSS Overall score: 7.2
CVSS v3 vector: AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C

The security implications are critical in our opinion. Every RakNet instance is susceptive to the attack. No authentication is required. If the attack is successful, the instance will become unresponsive persistently (DoS attack) until the server is restarted.
If an upgrade of the server side is not reasonable to resolve the vulnerability, we offer alternative approaches to mitigate attacks relying on this issue. Please contact us at security@slikesoft.com.