### PR TITLE
Add upper limit for file size transfers (CVSS score: 4.0)

### DIFF
--- a/Source/FileListTransfer.cpp
+++ b/Source/FileListTransfer.cpp
@@ -759,7 +759,10 @@ void FileListTransfer::OnReferencePush(Packet *packet, bool isTheFullFile)
 	FLR_MemoryBlock mb;
 	if (fileListReceiver->pushedFiles.Has(onFileStruct.fileIndex)==false)
 	{
-		mb.flrMemoryBlock=(char*) rakMalloc_Ex(onFileStruct.byteLengthOfThisFile, _FILE_AND_LINE_);
+		if (onFileStruct.byteLengthOfThisFile <= RAKNET_MAX_RETRIEVABLE_FILESIZE)
+			mb.flrMemoryBlock=(char*) rakMalloc_Ex(onFileStruct.byteLengthOfThisFile, _FILE_AND_LINE_);
+		else
+			mb.flrMemoryBlock = nullptr;
 		fileListReceiver->pushedFiles.SetNew(onFileStruct.fileIndex, mb);
 	}
 	else

--- a/Source/RakNetDefines.h
+++ b/Source/RakNetDefines.h
@@ -192,4 +192,12 @@
 
 //#define USE_THREADED_SEND
 
+// Controls the maximum retrievable filesize for incoming files using FileListTransfer.
+// The configured limit only applies for files which are transferred incrementally (which basically applies to any larger file).
+// Note that this also impacts the upper limit for memory allocations. It's suggested to redefine the value to a reasonable smaller size in the RakNetDefineOverrides.h header file.
+// For backwards compatibility with RakNet, the default is set to 4 GiB-1.
+#ifndef RAKNET_MAX_RETRIEVABLE_FILESIZE
+#define RAKNET_MAX_RETRIEVABLE_FILESIZE (0xFFFFFFFF)
+#endif
+
 #endif // __RAKNET_DEFINES_H


### PR DESCRIPTION
This is a backport of a security relevant fix for RakNet which was brought to our attention by a user - see SLikeSoft#19 for details. The issue has already been fixed in SLikeNet 0.1.1 (see https://www.slikenet.com/).
We provide this backport for people who prefer to stick with the RakNet project and also in order to easier share this fix with other RakNet forks.

CVSS Base score: 4.3
CVSS Temporal score: 4.0
CVSS Overall score: 4.0
CVSS v3 vector: AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L/E:F/RL:O/RC:C

The security implications are medium in our opinion. The issue only applies in applications which utilize the FileListTransfer class (f.e. used via the Autopatcher). When limiting the usage to the core functionality of RakNet, the app cannot be exploited via the vulnerability. If the app/game requires prior authentication, only authenticated users can exploit the vulnerability.
The problem surfaces by RakNet allowing unbound memory allocations when retrieving large files (up to 4GiB). If the allocation doesn't fail, RakNet will consume the amount of memory for as long as the file transfer takes. This can be used for DoS attacks ultimately trying to deplete the system resources on the server.
This pull requests adds a new compile time config value which should be defined to a reasonable value (f.e. 10 MB) based on the largest files which the game/app will transmit.