### PR TITLE
Fix potential non-null-terminated string in Irrlicht sample (CVSS score: n/a)

### DIFF
--- a/DependentExtensions/IrrlichtDemo/RakNetStuff.cpp
+++ b/DependentExtensions/IrrlichtDemo/RakNetStuff.cpp
@@ -228,7 +228,9 @@ void PlayerReplica::PostDeserializeConstruction(RakNet::BitStream *constructionB
 	model->setVisible(true);
 	model->setAnimationEndCallback(this);
 	wchar_t playerNameWChar[1024];
-	mbstowcs(playerNameWChar, playerName.C_String(), 1024);
+	mbstowcs(playerNameWChar, playerName.C_String(), 1023);
+	// ensure wide-character string is null terminated (i.e. if playerName length is >= 1023)
+	playerNameWChar[1023] = L'\0';
 	scene::IBillboardSceneNode *bb = sm->addBillboardTextSceneNode(0, playerNameWChar, model);
 	bb->setSize(core::dimension2df(40,20));
 	bb->setPosition(core::vector3df(0,model->getBoundingBox().MaxEdge.Y+bb->getBoundingBox().MaxEdge.Y-bb->getBoundingBox().MinEdge.Y+5.0,0));


### PR DESCRIPTION
This is a backport of a security relevant fix for RakNet, we discovered. The issue has already been fixed in SLikeNet 0.1.0 (see https://www.slikenet.com/).
We provide this backport for people who prefer to stick with the RakNet project and also in order to easier share this fix with other RakNet forks.

We could/did not calculate a CVSS score, since such score heavily depends on how exactly the 3rd-party-library (IrrlichtEngine) handles the potentially non-null-terminated string. Note that this can also differ between different versions of the 3rd-party-library.

The security implications of the issue should be considered low. It's only an issue in the sample integration and therefore only applies to games/apps which make use of the code provided in RakNetStuff for their integration with the IrrlichtEngine. Since a non-null-terminated string however can result in out of bounds memory access, we decided to treat this issue as a potential security vulnerability.