### PR TITLE
Restore NatPunchthrough default server support

### DIFF
--- a/DependentExtensions/IrrlichtDemo/RakNetStuff.h
+++ b/DependentExtensions/IrrlichtDemo/RakNetStuff.h
@@ -43,7 +43,7 @@ extern PlayerReplica *playerReplica; // Network object that represents the playe
 
 // A NAT punchthrough and proxy server Jenkins Software is hosting for free, should usually be online
 #define DEFAULT_NAT_PUNCHTHROUGH_FACILITATOR_PORT 61111
-#define DEFAULT_NAT_PUNCHTHROUGH_FACILITATOR_IP "natpunch.jenkinssoftware.com"
+#define DEFAULT_NAT_PUNCHTHROUGH_FACILITATOR_IP "natpunch.slikesoft.com"
 
 void InstantiateRakNetClasses(void);
 void DeinitializeRakNetClasses(void);

--- a/Samples/AutopatcherClient/AutopatcherClientTest.cpp
+++ b/Samples/AutopatcherClient/AutopatcherClientTest.cpp
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
 		printf("Enter server IP: ");
 		Gets(buff,sizeof(buff));
 		if (buff[0]==0)
-			//strcpy(buff, "natpunch.jenkinssoftware.com");
+			//strcpy(buff, "natpunch.slikesoft.com");
 			strcpy(buff, "127.0.0.1");
 	}
 	else

--- a/Samples/BigPacketTest/BigPacketTest.cpp
+++ b/Samples/BigPacketTest/BigPacketTest.cpp
@@ -55,7 +55,7 @@ int main(void)
 		printf("Enter remote IP: ");
 		Gets(text,BIG_PACKET_SIZE);
 		if (text[0]==0)
-			strcpy(text, "natpunch.jenkinssoftware.com"); // dx in Europe
+			strcpy(text, "natpunch.slikesoft.com"); // dx in Europe
 	}
 	else if (ch=='s')
 	{

--- a/Samples/Chat Example/Chat Example Client.cpp
+++ b/Samples/Chat Example/Chat Example Client.cpp
@@ -88,7 +88,7 @@ int main(void)
 	client->AllowConnectionResponseIPMigration(false);
 	if (ip[0]==0)
 		strcpy(ip, "127.0.0.1");
-	// strcpy(ip, "natpunch.jenkinssoftware.com");
+	// strcpy(ip, "natpunch.slikesoft.com");
 	
 		
 	puts("Enter the port to connect to");

--- a/Samples/ComprehensivePCGame/ComprehensivePCGame.cpp
+++ b/Samples/ComprehensivePCGame/ComprehensivePCGame.cpp
@@ -43,7 +43,7 @@
 
 #define DEFAULT_SERVER_PORT "61111"
 // Public test server
-#define DEFAULT_SERVER_ADDRESS "natpunch.jenkinssoftware.com"
+#define DEFAULT_SERVER_ADDRESS "natpunch.slikesoft.com"
 #define NAT_TYPE_DETECTION_SERVER 0
 #define USE_UPNP 1
 #define MASTER_SERVER_ADDRESS "masterserver2.raknet.com"

--- a/Samples/NATCompleteClient/main.cpp
+++ b/Samples/NATCompleteClient/main.cpp
@@ -37,7 +37,7 @@ using namespace RakNet;
 #define DEFAULT_RAKPEER_PORT 50000
 #define RAKPEER_PORT_STR "0"
 #define DEFAULT_SERVER_PORT "61111"
-#define DEFAULT_SERVER_ADDRESS "natpunch.jenkinssoftware.com"
+#define DEFAULT_SERVER_ADDRESS "natpunch.slikesoft.com"
 
 enum SampleResult
 {

--- a/Samples/PacketConsoleLogger/main.cpp
+++ b/Samples/PacketConsoleLogger/main.cpp
@@ -51,7 +51,7 @@ void main(void)
 		RakSleep(30);
 	}
 
-	RakNet::ConnectionAttemptResult car = rakPeer->Connect("natpunch.jenkinssoftware.com", 61111, 0, 0);
+	RakNet::ConnectionAttemptResult car = rakPeer->Connect("natpunch.slikesoft.com", 61111, 0, 0);
 	(void) car;
 	while (1)
 	{

--- a/Samples/RakVoice/main.cpp
+++ b/Samples/RakVoice/main.cpp
@@ -151,7 +151,7 @@ int main(void)
 		printf("Enter IP of facilitator (enter for default): ");
 		Gets(facilitatorIP,sizeof(facilitatorIP));
 		if (facilitatorIP[0]==0)
-			strcpy(facilitatorIP, "natpunch.jenkinssoftware.com");
+			strcpy(facilitatorIP, "natpunch.slikesoft.com");
 		facilitator.FromString(facilitatorIP);
 		facilitator.SetPortHostOrder(NAT_PUNCHTHROUGH_FACILITATOR_PORT);
 		rakPeer->Connect(facilitatorIP, NAT_PUNCHTHROUGH_FACILITATOR_PORT, 0, 0);

--- a/Samples/Reliable Ordered Test/ReliableOrderedTest.cpp
+++ b/Samples/Reliable Ordered Test/ReliableOrderedTest.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
 		Gets(ip, sizeof(ip));
 		if (ip[0]==0)
 			strcpy(ip, "127.0.0.1");
-			// strcpy(ip, "natpunch.jenkinssoftware.com");
+			// strcpy(ip, "natpunch.slikesoft.com");
 		
 		printf("Enter remote port: ");
 		Gets(str, sizeof(str));

--- a/Source/RakNetTypes.cpp
+++ b/Source/RakNetTypes.cpp
@@ -75,7 +75,7 @@ bool RakNet::NonNumericHostString( const char *host )
 	unsigned int i=0;
 	while (host[i])
 	{
-		// IPV4: natpunch.jenkinssoftware.com
+		// IPV4: natpunch.slikesoft.com
 		// IPV6: fe80::7c:31f7:fec4:27de%14
 		if ((host[i]>='g' && host[i]<='z') ||
 			(host[i]>='A' && host[i]<='Z'))

--- a/Source/RakNetTypes.h
+++ b/Source/RakNetTypes.h
@@ -157,7 +157,7 @@ struct RAK_DLL_EXPORT SocketDescriptor
 	char hostAddress[32];
 
 	/// IP version: For IPV4, use AF_INET (default). For IPV6, use AF_INET6. To autoselect, use AF_UNSPEC.
-	/// IPV6 is the newer internet protocol. Instead of addresses such as natpunch.jenkinssoftware.com, you may have an address such as fe80::7c:31f7:fec4:27de%14.
+	/// IPV6 is the newer internet protocol. Instead of addresses such as natpunch.slikesoft.com, you may have an address such as fe80::7c:31f7:fec4:27de%14.
 	/// Encoding takes 16 bytes instead of 4, so IPV6 is less efficient for bandwidth.
 	/// On the positive side, NAT Punchthrough is not needed and should not be used with IPV6 because there are enough addresses that routers do not need to create address mappings.
 	/// RakPeer::Startup() will fail if this IP version is not supported.


### PR DESCRIPTION
RakNet provided a default natpunchthrough service at natpunch.jenkinssoftware.com. This service was shutdown in 2015. SLikeSoft provides a continuation of the free service at natpunch.slikesoft.com which is fully backwards compatible with RakNet 4.081/4.082.

This patch replaces the default natpunchthrough URLs throughout the code and directs them to the SLikeSoft server instead.