### PR TITLE
Fixed buffer overrun in PacketizedTCP::SendList() (CVSS score: n/a)

### DIFF
--- a/Source/PacketizedTCP.cpp
+++ b/Source/PacketizedTCP.cpp
@@ -11,11 +11,15 @@
 #include "NativeFeatureIncludes.h"
 #if _RAKNET_SUPPORT_PacketizedTCP==1 && _RAKNET_SUPPORT_TCPInterface==1
 
+#include <algorithm> // used for std::min
 #include "PacketizedTCP.h"
 #include "NativeTypes.h"
 #include "BitStream.h"
 #include "MessageIdentifiers.h"
 #include "RakAlloca.h"
+#ifdef min
+#undef min
+#endif
 
 using namespace RakNet;
 
@@ -96,7 +100,7 @@ bool PacketizedTCP::SendList( const char **data, const unsigned int *lengths, co
 		dataArray[i+1]=data[i];
 		lengthsArray[i+1]=lengths[i];
 	}	
-	return TCPInterface::SendList(dataArray,lengthsArray,numParameters+1,systemAddress,broadcast);
+	return TCPInterface::SendList(dataArray, lengthsArray, std::min(numParameters, 511) + 1, systemAddress, broadcast);
 }
 void PacketizedTCP::PushNotificationsToQueues(void)
 {


### PR DESCRIPTION
This is a backport of a security relevant fix for RakNet. 
The issue has already been fixed in SLikeNet 0.1.3 (see https://www.slikenet.com/).
We provide this backport for people who prefer to stick with the RakNet project and also in order to easier share this fix with other RakNet forks.

A CVSS score cannot be calculated for this one, as no direct usage of PacketizedTCP::SendList() is flawed in RakNet. The issue is therefore only triggered if 3rd-party programs using RakNet make use of the method and pass in more than 512 parameters.
This is a use case which is expected to be far off from reality, so the real world security implications are likely to be non-existant.