### PR TITLE
Fix for multiple security vulnerabilities in BitStream.

### DIFF
--- a/Source/BitStream.h
+++ b/Source/BitStream.h
@@ -511,7 +511,7 @@ namespace RakNet
 		void SetReadOffset( const BitSize_t newReadOffset ) {readOffset=newReadOffset;}
 
 		/// \brief Returns the number of bits left in the stream that haven't been read
-		inline BitSize_t GetNumberOfUnreadBits( void ) const {return numberOfBitsUsed - readOffset;}
+		inline BitSize_t GetNumberOfUnreadBits( void ) const { return readOffset > numberOfBitsUsed ? 0 : numberOfBitsUsed - readOffset; }
 
 		/// \brief Makes a copy of the internal data for you \a _data will point to
 		/// the stream. Partial bytes are left aligned.
@@ -1474,7 +1474,7 @@ namespace RakNet
 	template <>
 		inline bool BitStream::Read(bool &outTemplateVar)
 	{
-		if ( readOffset + 1 > numberOfBitsUsed )
+		if (GetNumberOfUnreadBits() == 0)
 			return false;
 
 		if ( data[ readOffset >> 3 ] & ( 0x80 >> ( readOffset & 7 ) ) )   // Is it faster to just write it out here?
@@ -1524,7 +1524,7 @@ namespace RakNet
 	inline bool BitStream::Read(uint24_t &outTemplateVar)
 	{
 		AlignReadToByteBoundary();
-		if ( readOffset + 3*8 > numberOfBitsUsed )
+		if (GetNumberOfUnreadBits() < 3 * 8)
 			return false;
 
 		if (IsBigEndian()==false)


### PR DESCRIPTION
This is a backport of a multiple security relevant fixes for RakNet. One of these was brought to our attention by @Mellnik.

CVSS Base score: 7.6
CVSS Temporal score: 7.1
CVSS Overall score: 7.1
CVSS v3 Vector: AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H/E:F/RL:O/RC:C

The security implications of these issues are multifold and spread throughout RakNet. These range from risks of leaking arbitrary data (which can also include data outside the running application), writing data to memory (and potentially also files), and also potential DoS-attacks.

As far as our investigation goes, these vulnerabilities can not be used to bypass server authentication. This means that servers which require authentication (f.e. through a password) are not vulnerable by these issues through anonymous access.

If the server doesn't require prior authentication or if an attacker successfully authenticates with the server, it is however vulnerable by multiple attack vectors. Usage of certain (optional) RakNet features can increase the risk significantly, though it must be noted that even if only the standard functionality is used, there's a very high risk of at least suffering potential data leaks as well as being vulnerable to DoS-attacks.